### PR TITLE
Optimizations on the loop blocking

### DIFF
--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -62,9 +62,9 @@ namespace gridtools::fn::sid_neighbor_table {
             static_assert(!std::is_same_v<IndexDimension, NeighborDimension>,
                 "The index dimension and the neighbor dimension must be different.");
 
-            const auto const_sid = sid::add_const(std::true_type{}, sid);
-            const auto origin = get_origin(const_sid);
-            const auto strides = sid::get_strides(sid);
+            const auto const_sid = sid::as_const(std::forward<Sid>(sid));
+            const auto origin = sid::get_origin(const_sid);
+            const auto strides = sid::get_strides(const_sid);
 
             return sid_neighbor_table<IndexDimension,
                 NeighborDimension,

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -15,6 +15,7 @@
 #include "../common/array.hpp"
 #include "../common/ldg_ptr.hpp"
 #include "../fn/unstructured.hpp"
+#include "../sid/as_const.hpp"
 #include "../sid/concept.hpp"
 
 namespace gridtools::fn::sid_neighbor_table {
@@ -40,7 +41,7 @@ namespace gridtools::fn::sid_neighbor_table {
 
             using namespace gridtools::literals;
 
-            const auto* ptr = table.origin();
+            auto ptr = table.origin();
             using element_type = std::decay_t<decltype(*ptr)>;
 
             gridtools::array<element_type, MaxNumNeighbors> neighbors;
@@ -61,13 +62,14 @@ namespace gridtools::fn::sid_neighbor_table {
             static_assert(!std::is_same_v<IndexDimension, NeighborDimension>,
                 "The index dimension and the neighbor dimension must be different.");
 
-            const auto origin = sid::get_origin(sid);
+            auto const_sid = sid::add_const(std::true_type{}, sid);
+            auto origin = get_origin(const_sid);
             const auto strides = sid::get_strides(sid);
 
             return sid_neighbor_table<IndexDimension,
                 NeighborDimension,
                 MaxNumNeighbors,
-                sid::ptr_holder_type<Sid>,
+                decltype(origin),
                 sid::strides_type<Sid>>{
                 origin, strides}; // Note: putting the return type into the function signature will crash nvcc 12.0
         }

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -62,8 +62,8 @@ namespace gridtools::fn::sid_neighbor_table {
             static_assert(!std::is_same_v<IndexDimension, NeighborDimension>,
                 "The index dimension and the neighbor dimension must be different.");
 
-            auto const_sid = sid::add_const(std::true_type{}, sid);
-            auto origin = get_origin(const_sid);
+            const auto const_sid = sid::add_const(std::true_type{}, sid);
+            const auto origin = get_origin(const_sid);
             const auto strides = sid::get_strides(sid);
 
             return sid_neighbor_table<IndexDimension,

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -40,7 +40,7 @@ namespace gridtools::fn::sid_neighbor_table {
 
             using namespace gridtools::literals;
 
-            const auto* __restrict__ ptr = table.origin();
+            const auto* ptr = table.origin();
             using element_type = std::decay_t<decltype(*ptr)>;
 
             gridtools::array<element_type, MaxNumNeighbors> neighbors;

--- a/include/gridtools/fn/sid_neighbor_table.hpp
+++ b/include/gridtools/fn/sid_neighbor_table.hpp
@@ -40,7 +40,7 @@ namespace gridtools::fn::sid_neighbor_table {
 
             using namespace gridtools::literals;
 
-            auto ptr = table.origin();
+            const auto* __restrict__ ptr = table.origin();
             using element_type = std::decay_t<decltype(*ptr)>;
 
             gridtools::array<element_type, MaxNumNeighbors> neighbors;

--- a/include/gridtools/fn/unstructured.hpp
+++ b/include/gridtools/fn/unstructured.hpp
@@ -87,10 +87,7 @@ namespace gridtools::fn {
         template <class Tag, class Ptr, class Strides, class Domain, class Conn, class Offset>
         GT_FUNCTION constexpr auto horizontal_shift(iterator<Tag, Ptr, Strides, Domain> const &it, Conn, Offset) {
             auto const &table = host_device::at_key<Conn>(it.m_domain.m_tables);
-            const auto* __restrict__ r_table = &table;
-            const auto neigbors = it.m_index == -1 ? decltype(neighbor_table::neighbors(*r_table, it.m_index)){} : neighbor_table::neighbors(*r_table, it.m_index);
-            const auto* __restrict__ r_neighbors = it.m_index == -1 ? nullptr : neigbors.data();
-            const auto new_index = it.m_index == -1 ? -1 : r_neighbors[Offset::value];
+            auto new_index = it.m_index == -1 ? -1 : get<Offset::value>(neighbor_table::neighbors(table, it.m_index));
             auto shifted = it;
             shifted.m_index = new_index;
             return shifted;

--- a/include/gridtools/fn/unstructured.hpp
+++ b/include/gridtools/fn/unstructured.hpp
@@ -88,9 +88,9 @@ namespace gridtools::fn {
         GT_FUNCTION constexpr auto horizontal_shift(iterator<Tag, Ptr, Strides, Domain> const &it, Conn, Offset) {
             auto const &table = host_device::at_key<Conn>(it.m_domain.m_tables);
             const auto* __restrict__ r_table = &table;
-            const auto* __restrict__ r_neighbors = neighbor_table::neighbors(*r_table, it.m_index).data();
-            // printf("r_neighbors: %p, &r_neighbors[Offset::value]: %p, Offset::value: %d\n", r_neighbors, &r_neighbors[Offset::value], Offset::value);
-            const auto new_index = r_neighbors[Offset::value];
+            const auto neigbors = it.m_index == -1 ? decltype(neighbor_table::neighbors(*r_table, it.m_index)){} : neighbor_table::neighbors(*r_table, it.m_index);
+            const auto* __restrict__ r_neighbors = it.m_index == -1 ? nullptr : neigbors.data();
+            const auto new_index = it.m_index == -1 ? -1 : r_neighbors[Offset::value];
             auto shifted = it;
             shifted.m_index = new_index;
             return shifted;

--- a/include/gridtools/fn/unstructured.hpp
+++ b/include/gridtools/fn/unstructured.hpp
@@ -87,7 +87,10 @@ namespace gridtools::fn {
         template <class Tag, class Ptr, class Strides, class Domain, class Conn, class Offset>
         GT_FUNCTION constexpr auto horizontal_shift(iterator<Tag, Ptr, Strides, Domain> const &it, Conn, Offset) {
             auto const &table = host_device::at_key<Conn>(it.m_domain.m_tables);
-            auto new_index = it.m_index == -1 ? -1 : get<Offset::value>(neighbor_table::neighbors(table, it.m_index));
+            const auto* __restrict__ r_table = &table;
+            const auto* __restrict__ r_neighbors = neighbor_table::neighbors(*r_table, it.m_index).data();
+            // printf("r_neighbors: %p, &r_neighbors[Offset::value]: %p, Offset::value: %d\n", r_neighbors, &r_neighbors[Offset::value], Offset::value);
+            const auto new_index = r_neighbors[Offset::value];
             auto shifted = it;
             shifted.m_index = new_index;
             return shifted;

--- a/include/gridtools/fn/unstructured.hpp
+++ b/include/gridtools/fn/unstructured.hpp
@@ -90,7 +90,7 @@ namespace gridtools::fn {
             const auto* __restrict__ r_table = &table;
             const auto* __restrict__ r_neighbors = neighbor_table::neighbors(*r_table, it.m_index).data();
             // printf("r_neighbors: %p, &r_neighbors[Offset::value]: %p, Offset::value: %d\n", r_neighbors, &r_neighbors[Offset::value], Offset::value);
-            const auto new_index = r_neighbors[Offset::value];
+            const auto new_index = *as_ldg_ptr(&r_neighbors[Offset::value]);
             auto shifted = it;
             shifted.m_index = new_index;
             return shifted;

--- a/include/gridtools/fn/unstructured.hpp
+++ b/include/gridtools/fn/unstructured.hpp
@@ -90,7 +90,7 @@ namespace gridtools::fn {
             const auto* __restrict__ r_table = &table;
             const auto* __restrict__ r_neighbors = neighbor_table::neighbors(*r_table, it.m_index).data();
             // printf("r_neighbors: %p, &r_neighbors[Offset::value]: %p, Offset::value: %d\n", r_neighbors, &r_neighbors[Offset::value], Offset::value);
-            const auto new_index = *as_ldg_ptr(&r_neighbors[Offset::value]);
+            const auto new_index = r_neighbors[Offset::value];
             auto shifted = it;
             shifted.m_index = new_index;
             return shifted;

--- a/include/gridtools/storage/adapter/nanobind_adapter.hpp
+++ b/include/gridtools/storage/adapter/nanobind_adapter.hpp
@@ -91,29 +91,20 @@ namespace gridtools {
             std::copy_n(ndarray.stride_ptr(), ndim, strides.begin());
             const auto static_strides = select_static_strides(stride_spec, strides.data());
 
-            return sid::synthetic()
-                .template set<property::origin>(sid::host_device::simple_ptr_holder<T *>{ptr})
-                .template set<property::strides>(static_strides)
-                .template set<property::strides_kind, StridesKind>()
-                .template set<property::lower_bounds>(gridtools::array<integral_constant<std::size_t, 0>, ndim>())
-                .template set<property::upper_bounds>(shape);
-        }
-
-        template <class T,
-            array_size_t... Sizes,
-            class... Args,
-            class Strides = fully_dynamic_strides<sizeof...(Sizes)>,
-            class StridesKind = sid::unknown_kind>
-        auto as_const_sid(nanobind::ndarray<T, nanobind::shape<Sizes...>, Args...> ndarray,
-            Strides stride_spec = {},
-            StridesKind strides_kind = {}) {
-            return sid::as_const(as_sid(ndarray, stride_spec, strides_kind));
+            return sid::add_const(
+                    std::integral_constant<bool, ndarray.ReadOnly>{},
+                    sid::synthetic()
+                        .template set<property::origin>(sid::host_device::simple_ptr_holder<T *>{ptr})
+                        .template set<property::strides>(static_strides)
+                        .template set<property::strides_kind, StridesKind>()
+                        .template set<property::lower_bounds>(gridtools::array<integral_constant<std::size_t, 0>, ndim>())
+                        .template set<property::upper_bounds>(shape)
+                );
         }
     } // namespace nanobind_sid_adapter_impl_
 
     namespace nanobind {
         using nanobind_sid_adapter_impl_::as_sid;
-        using nanobind_sid_adapter_impl_::as_const_sid;
         using nanobind_sid_adapter_impl_::dynamic_size;
         using nanobind_sid_adapter_impl_::fully_dynamic_strides;
         using nanobind_sid_adapter_impl_::stride_spec;

--- a/include/gridtools/storage/adapter/nanobind_adapter.hpp
+++ b/include/gridtools/storage/adapter/nanobind_adapter.hpp
@@ -18,6 +18,7 @@
 #include "../../common/array.hpp"
 #include "../../common/integral_constant.hpp"
 #include "../../common/tuple.hpp"
+#include "../../sid/as_const.hpp"
 #include "../../sid/simple_ptr_holder.hpp"
 #include "../../sid/synthetic.hpp"
 #include "../../sid/unknown_kind.hpp"
@@ -97,10 +98,22 @@ namespace gridtools {
                 .template set<property::lower_bounds>(gridtools::array<integral_constant<std::size_t, 0>, ndim>())
                 .template set<property::upper_bounds>(shape);
         }
+
+        template <class T,
+            array_size_t... Sizes,
+            class... Args,
+            class Strides = fully_dynamic_strides<sizeof...(Sizes)>,
+            class StridesKind = sid::unknown_kind>
+        auto as_const_sid(nanobind::ndarray<T, nanobind::shape<Sizes...>, Args...> ndarray,
+            Strides stride_spec_ = {},
+            StridesKind = {}) {
+            return sid::add_const(std::true_type{}, as_sid(ndarray, stride_spec_, StridesKind{}));
+        }
     } // namespace nanobind_sid_adapter_impl_
 
     namespace nanobind {
         using nanobind_sid_adapter_impl_::as_sid;
+        using nanobind_sid_adapter_impl_::as_const_sid;
         using nanobind_sid_adapter_impl_::dynamic_size;
         using nanobind_sid_adapter_impl_::fully_dynamic_strides;
         using nanobind_sid_adapter_impl_::stride_spec;

--- a/include/gridtools/storage/adapter/nanobind_adapter.hpp
+++ b/include/gridtools/storage/adapter/nanobind_adapter.hpp
@@ -79,7 +79,7 @@ namespace gridtools {
             class Strides = fully_dynamic_strides<sizeof...(Sizes)>,
             class StridesKind = sid::unknown_kind>
         auto as_sid(nanobind::ndarray<T, nanobind::shape<Sizes...>, Args...> ndarray,
-            Strides stride_spec_ = {},
+            Strides stride_spec = {},
             StridesKind = {}) {
             using sid::property;
             const auto ptr = ndarray.data();
@@ -87,13 +87,13 @@ namespace gridtools {
             assert(ndim == ndarray.ndim());
             gridtools::array<std::size_t, ndim> shape;
             std::copy_n(ndarray.shape_ptr(), ndim, shape.begin());
-            gridtools::array<std::size_t, ndim> strides_;
-            std::copy_n(ndarray.stride_ptr(), ndim, strides_.begin());
-            const auto strides = select_static_strides(stride_spec_, strides_.data());
+            gridtools::array<std::size_t, ndim> strides;
+            std::copy_n(ndarray.stride_ptr(), ndim, strides.begin());
+            const auto static_strides = select_static_strides(stride_spec, strides.data());
 
             return sid::synthetic()
                 .template set<property::origin>(sid::host_device::simple_ptr_holder<T *>{ptr})
-                .template set<property::strides>(strides)
+                .template set<property::strides>(static_strides)
                 .template set<property::strides_kind, StridesKind>()
                 .template set<property::lower_bounds>(gridtools::array<integral_constant<std::size_t, 0>, ndim>())
                 .template set<property::upper_bounds>(shape);
@@ -105,9 +105,9 @@ namespace gridtools {
             class Strides = fully_dynamic_strides<sizeof...(Sizes)>,
             class StridesKind = sid::unknown_kind>
         auto as_const_sid(nanobind::ndarray<T, nanobind::shape<Sizes...>, Args...> ndarray,
-            Strides stride_spec_ = {},
-            StridesKind = {}) {
-            return sid::add_const(std::true_type{}, as_sid(ndarray, stride_spec_, StridesKind{}));
+            Strides stride_spec = {},
+            StridesKind strides_kind = {}) {
+            return sid::as_const(as_sid(ndarray, stride_spec, strides_kind));
         }
     } // namespace nanobind_sid_adapter_impl_
 


### PR DESCRIPTION
- [x] Read neighbors only once for the unrolled loop and then only once for the epilogue loop
- [x] Create `as_const_sid` for `nanobind_adapter` to be able to pass the input fields as `const` and allow the compiler to apply optimizations like avoiding reading vertically independent fields in every k loop iteration (based on Felix's suggestion)
- [x] It was too painful to reuse `as_sid` from `as_const_sid` by adding a `bool` template parameter to `as_sid` and depending on that call `add_const` due to the variadic parameters. Maybe try and find a way to make it better?

The idea behind `as_const_sid` is to be called by the `nanobind` bindings generated by `gt4py` only for the input fields. Some extra work is necessary for that.